### PR TITLE
Update `gcry_md_start_debug` to `gcry_md_debug`

### DIFF
--- a/encr-data.c
+++ b/encr-data.c
@@ -119,7 +119,7 @@ decrypt_data( void *procctx, PKT_encrypted *ed, DEK *dek )
       if (gcry_md_open (&dfx->mdc_hash, ed->mdc_method, 0 ))
         BUG ();
       if ( DBG_HASHING )
-        gcry_md_start_debug (dfx->mdc_hash, "checkmdc");
+        gcry_md_debug (dfx->mdc_hash, "checkmdc");
     }
 
   rc = openpgp_cipher_open (&dfx->cipher_hd, dek->algo,

--- a/mp.c
+++ b/mp.c
@@ -289,9 +289,9 @@ proc_plaintext( CTX c, PACKET *pkt )
         BUG ();
     }
     if ( DBG_HASHING ) {
-	gcry_md_start_debug ( c->mfx.md, "verify" );
+	gcry_md_debug ( c->mfx.md, "verify" );
 	if ( c->mfx.md2  )
-	    gcry_md_start_debug ( c->mfx.md2, "verify2" );
+	    gcry_md_debug ( c->mfx.md2, "verify2" );
     }
 
     rc=0;


### PR DESCRIPTION
Since libgcrypt 1.6.0, the deprecated message digest debug macros have
been removed. The `gcry_md_debug` should be used instead.

Reference: http://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blob;f=NEWS;h=0150fdd6003172cc87d7f082a53a51f05644e206;hb=HEAD#l44
